### PR TITLE
Add crossfade (option) and fix context resume bug

### DIFF
--- a/loopify.js
+++ b/loopify.js
@@ -56,12 +56,17 @@
       function success(buffer) {
 
         var source;
+        var future_id; // id of the timeout for the next play
 
         function canPlay() {
           return can_play;
         }
 
-        function play() {
+        function play(fade_time) {
+        
+          if (fade_time === undefined) {
+            fade_time = 0.0;
+          }
 
           // We cannot play yet, but maybe this was triggered by our first
           // interaction with the page, and we will be able to play soon.
@@ -77,16 +82,45 @@
           // Stop if it's already playing
           stop();
 
-          // Create a new source (can't replay an existing source)
-          source = context.createBufferSource();
-          source.connect(context.destination);
+          // Called at the start of the new segment, 'fade_time' before
+          // the end of the previous one
+          function playSegment(prev_gain) {
+            var now = context.currentTime;
 
-          // Set the buffer
-          source.buffer = buffer;
-          source.loop = true;
+            // Create a new source (can't replay an existing source)
+            source = context.createBufferSource();
+            var gain = context.createGain();
+            source.connect(gain).connect(context.destination);
+            source.buffer = buffer;
 
-          // Play it
-          source.start(0);
+            // Fade in this segment
+            gain.gain.setValueAtTime(0, now);
+            gain.gain.linearRampToValueAtTime(1, now + fade_time);
+
+            // Crossfade with previous segment if it exists
+            if (prev_gain !== undefined) {
+              prev_gain.gain.linearRampToValueAtTime(0, now + fade_time);
+            }
+
+            // start source
+            source.start(now);
+
+            return gain;
+          }
+        
+          // Play segment and recursively schedule the next one
+          function recursivePlay(prev_gain) {
+            // Play the current segment
+            var gain = playSegment(prev_gain);
+            
+            // Schedule ourselves to play the next segment
+            future_id = setTimeout(() => {
+              recursivePlay(gain);
+            }, (buffer.duration - fade_time) * 1000);
+            console.log("schedule done");
+          }
+
+          recursivePlay();
 
         }
 
@@ -98,6 +132,12 @@
           if (source) {
             source.stop();
             source = null;
+          }
+
+          // Clear any future play timeouts
+          if (future_id) {
+            clearTimeout(future_id);
+            future_id = null;
           }
 
         }

--- a/loopify.js
+++ b/loopify.js
@@ -19,7 +19,6 @@
 
       function resume() {
         timeout(context.resume(), resume_timeout).then(() => {
-
             // Context is resumed! We can play audio now.
             can_play = true;
 
@@ -33,7 +32,12 @@
         }, resume);
       }
 
-      resume();
+      if (context.state === "running") {
+        // no need to resume, we can play
+        can_play = true;
+      } else {
+        resume();
+      }
 
       request.responseType = "arraybuffer";
       request.open("GET", uri, true);

--- a/loopify.js
+++ b/loopify.js
@@ -11,7 +11,7 @@
       // Try to resume it every 100ms, only once successful we can play
       var can_play = false;
       var want_to_play = false; // if we want to play but can't yet
-      var resume_timeout = 100;
+      var resume_timeout = 100; // milliseconds
 
       const timeout = (prom, time) => {
         return Promise.race([prom, new Promise((_r, rej) => setTimeout(rej, time))])
@@ -25,15 +25,13 @@
             // I we want to play, do it now
             if (want_to_play) {
               want_to_play = false;
-              if (obj !== undefined) {
-                obj.play();
-              }
+              if (obj !== undefined) obj.play();
             }
         }, resume);
       }
 
       if (context.state === "running") {
-        // no need to resume, we can play
+        // no need to resume, we can play already
         can_play = true;
       } else {
         resume();
@@ -61,10 +59,6 @@
 
         var source;
         var future_id ; // id of the timeout for the next play
-
-        function canPlay() {
-          return can_play;
-        }
 
         function play(fade_time) {
         

--- a/loopify.js
+++ b/loopify.js
@@ -117,7 +117,6 @@
             future_id = setTimeout(() => {
               recursivePlay(gain);
             }, (buffer.duration - fade_time) * 1000);
-            console.log("schedule done");
           }
 
           recursivePlay();

--- a/loopify.js
+++ b/loopify.js
@@ -56,7 +56,7 @@
       function success(buffer) {
 
         var source;
-        var future_id; // id of the timeout for the next play
+        var future_id ; // id of the timeout for the next play
 
         function canPlay() {
           return can_play;
@@ -141,10 +141,15 @@
 
         }
 
+        function playing() {
+          return source !== undefined;
+        }
+
         // Return the object to the callback
         obj = {
           play: play,
-          stop: stop
+          stop: stop,
+          playing: playing,
         }
 
         cb(null, obj);
@@ -153,7 +158,7 @@
 
     }
 
-    loopify.version = "0.1";
+    loopify.version = "0.2";
 
     if (typeof define === "function" && define.amd) {
       define(function() { return loopify; });

--- a/loopify.js
+++ b/loopify.js
@@ -2,12 +2,15 @@
 
     function loopify(uri,cb) {
 
-      var context = new (window.AudioContext || window.webkitAudioContext)(),
-          request = new XMLHttpRequest();
+      var context = new (window.AudioContext || window.webkitAudioContext)();
+      var request = new XMLHttpRequest();
+
+      var obj = undefined;
       
       // If we have not interacted with the page, we can't play audio
-      // Try to resume it every 100ms, only once su
+      // Try to resume it every 100ms, only once successful we can play
       var can_play = false;
+      var want_to_play = false; // if we want to play but can't yet
       var resume_timeout = 100;
 
       const timeout = (prom, time) => {
@@ -15,7 +18,19 @@
       };
 
       function resume() {
-        timeout(context.resume(), resume_timeout).then(() => {can_play = true}, resume);
+        timeout(context.resume(), resume_timeout).then(() => {
+
+            // Context is resumed! We can play audio now.
+            can_play = true;
+
+            // I we want to play, do it now
+            if (want_to_play) {
+              want_to_play = false;
+              if (obj !== undefined) {
+                obj.play();
+              }
+            }
+        }, resume);
       }
 
       resume();
@@ -48,10 +63,16 @@
 
         function play() {
 
-          // NOTE: we don't check for the 'can_play' flag here on purpose!!
-          // If the first time we interact with the page is, for example,
-          // pressing the play button, this would lead to a race condition
-          // and probably gobble up the first press of the button.
+          // We cannot play yet, but maybe this was triggered by our first
+          // interaction with the page, and we will be able to play soon.
+          // There is a race between call to play and the callback of the
+          // resume of the context. We just set a flag here, and return.
+          // The resume callback will check this flag and play if needed.
+          if (!can_play) {
+            // We can't play audio yet
+            want_to_play = true;
+            return;
+          }
 
           // Stop if it's already playing
           stop();
@@ -71,6 +92,8 @@
 
         function stop() {
 
+          want_to_play = false;
+
           // Stop and clear if it's playing
           if (source) {
             source.stop();
@@ -79,11 +102,13 @@
 
         }
 
-        cb(null,{
-          canPlay: canPlay,
+        // Return the object to the callback
+        obj = {
           play: play,
           stop: stop
-        });
+        }
+
+        cb(null, obj);
 
       }
 

--- a/loopify.js
+++ b/loopify.js
@@ -4,6 +4,21 @@
 
       var context = new (window.AudioContext || window.webkitAudioContext)(),
           request = new XMLHttpRequest();
+      
+      // If we have not interacted with the page, we can't play audio
+      // Try to resume it every 100ms, only once su
+      var can_play = false;
+      var resume_timeout = 100;
+
+      const timeout = (prom, time) => {
+        return Promise.race([prom, new Promise((_r, rej) => setTimeout(rej, time))])
+      };
+
+      function resume() {
+        timeout(context.resume(), resume_timeout).then(() => {can_play = true}, resume);
+      }
+
+      resume();
 
       request.responseType = "arraybuffer";
       request.open("GET", uri, true);
@@ -27,7 +42,16 @@
 
         var source;
 
+        function canPlay() {
+          return can_play;
+        }
+
         function play() {
+
+          // NOTE: we don't check for the 'can_play' flag here on purpose!!
+          // If the first time we interact with the page is, for example,
+          // pressing the play button, this would lead to a race condition
+          // and probably gobble up the first press of the button.
 
           // Stop if it's already playing
           stop();
@@ -56,6 +80,7 @@
         }
 
         cb(null,{
+          canPlay: canPlay,
           play: play,
           stop: stop
         });


### PR DESCRIPTION
First of all, thanks for a really helpful little bit of code! <3 

Regarding this PR: I've been using it to implement audio backend for wasm browser game. The browser does not allow one to play audio without interacting with the window first, which prevented the browser from playing the audio. First two commits add a periodic poll of `context.resume()` (which is behaving a bit weirdly so has to be wrapped in a timeout) to check whether we have successfully resumed the context and are able to play audio. There is a bit tricky case there which is resolved with the `want_to_play` flag (see comment).

The latter commits add a crossfade mechanism to the audio. The default behaviour is exactly as before. `play(0.1)` plays the track on loop and crossfades the last 0.1 seconds. Makes it sound bad in the demo (which is why i didn't add it there), but it helps with less-well-looped pieces of audio.

Finally added a `playing()` method to check if the audio is currently playing. A useful thing to be able to check; saves keeping track of it in a separate variable.